### PR TITLE
fix: only consider extensions at the end of filenames

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export function walk(input: Program | Node, options: Partial<WalkOptions>) {
   ) as Program | Node | null
 }
 
-const LANG_RE = createRegExp(exactly('jsx').or('tsx').or('js').or('ts').groupedAs('lang').after(exactly('.').and(anyOf('c', 'm').optionally())))
+const LANG_RE = createRegExp(exactly('jsx').or('tsx').or('js').or('ts').groupedAs('lang').after(exactly('.').and(anyOf('c', 'm').optionally())).at.lineEnd())
 
 /**
  * Parse the code and walk the AST with the given callback, which is called when entering a node.


### PR DESCRIPTION
This prevents paths like `foo/bar.js/index.ts` from incorrectly being parsed as js files.

(See https://github.com/nuxt/nuxt/issues/32663)

Edit:
I didn't see #110 when I submitted this. However, while it also fixes this problem, I do think that parsing the language based on the filename is safer than allowing it to be passed as an argument.