### PR TITLE
fix: surface load errors when resolving `parseSync`

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "exclude": ["catalog"],
-  "entry": ["src/index.ts", "vite.config.ts", "test/**/*.test.ts", "test/**/*.bench.ts"],
-  "ignoreDependencies": ["@vitest/coverage-v8", "@vue/compiler-sfc"]
+  "ignoreDependencies": ["@vue/compiler-sfc"],
+  "workspaces": {
+    ".": {
+      "entry": ["src/index.ts", "test/**/*.test.ts", "test/**/*.bench.ts"]
+    }
+  }
 }

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -21,22 +21,45 @@ type ParseSync = (
 
 let cachedParseSync: ParseSync | undefined;
 
-function resolveParseSync(): ParseSync {
-  if (cachedParseSync) return cachedParseSync;
-  const require = createRequire(import.meta.url);
+const MODULE_NOT_FOUND_CODES = new Set(["MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"]);
+
+/**
+ * Whether `error` means `id` itself is not installed, rather than `id` failing while loading
+ * (for example a package that is installed but is missing its platform-specific native binding).
+ */
+function isMissingModule(error: unknown, id: string): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const { code, message } = error as { code?: unknown; message?: unknown };
+  if (typeof code !== "string" || !MODULE_NOT_FOUND_CODES.has(code)) return false;
+  return typeof message === "string" && message.includes(`'${id}'`);
+}
+
+/** @internal exported for testing */
+export function _resolveParseSync(require: (id: string) => unknown): ParseSync {
   const candidates = ["oxc-parser", "rolldown/utils"] as const;
   for (const id of candidates) {
+    let mod: { parseSync?: ParseSync };
     try {
-      const mod = require(id) as { parseSync?: ParseSync };
-      if (typeof mod.parseSync === "function") {
-        cachedParseSync = mod.parseSync;
-        return cachedParseSync;
-      }
-    } catch {}
+      mod = require(id) as { parseSync?: ParseSync };
+    } catch (error) {
+      if (isMissingModule(error, id)) continue;
+      throw new Error(
+        `oxc-walker: found \`${id}\` but failed to load it. Pass a \`parseSync\` function via the \`parseAndWalk\` options to bypass this lookup.`,
+        { cause: error },
+      );
+    }
+    if (typeof mod.parseSync === "function") {
+      return mod.parseSync;
+    }
   }
   throw new Error(
     "oxc-walker: could not resolve a `parseSync` implementation. Install `oxc-parser` or `rolldown` (and use `rolldown/utils`), or pass a `parseSync` function via the `parseAndWalk` options.",
   );
+}
+
+function resolveParseSync(): ParseSync {
+  cachedParseSync ||= _resolveParseSync(createRequire(import.meta.url));
+  return cachedParseSync;
 }
 
 export type Identifier =

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -35,7 +35,7 @@ function isMissingModule(error: unknown, id: string): boolean {
 }
 
 /** @internal exported for testing */
-export function _resolveParseSync(require: (id: string) => unknown): ParseSync {
+export function _loadParseSync(require: (id: string) => unknown): ParseSync {
   const candidates = ["oxc-parser", "rolldown/utils"] as const;
   for (const id of candidates) {
     let mod: { parseSync?: ParseSync };
@@ -58,7 +58,7 @@ export function _resolveParseSync(require: (id: string) => unknown): ParseSync {
 }
 
 function resolveParseSync(): ParseSync {
-  cachedParseSync ||= _resolveParseSync(createRequire(import.meta.url));
+  cachedParseSync ||= _loadParseSync(createRequire(import.meta.url));
   return cachedParseSync;
 }
 

--- a/test/parse-sync-resolution.test.ts
+++ b/test/parse-sync-resolution.test.ts
@@ -1,0 +1,91 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { _loadParseSync } from "../src/walk";
+
+const realOxcParser = fileURLToPath(new URL("../node_modules/oxc-parser", import.meta.url));
+const reexportRealParser = `module.exports = require(${JSON.stringify(realOxcParser)});`;
+
+const fixtures: string[] = [];
+
+/**
+ * Create a directory containing real CommonJS packages, and return a `require` resolving
+ * against it. Nothing here is mocked: resolution failures come from Node itself.
+ * @param packages Map of package name to the body of its entry point.
+ */
+async function createRequireFor(packages: Record<string, string>) {
+  const dir = await mkdtemp(join(tmpdir(), "oxc-walker-"));
+  fixtures.push(dir);
+
+  for (const [name, body] of Object.entries(packages)) {
+    const pkgDir = join(dir, "node_modules", name);
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name, version: "0.0.0", main: "index.cjs" }),
+    );
+    await writeFile(join(pkgDir, "index.cjs"), body);
+  }
+
+  return createRequire(join(dir, "index.js"));
+}
+
+function parse(parseSync: ReturnType<typeof _loadParseSync>) {
+  return parseSync("test.js", "const a = 1").program.body[0]?.type;
+}
+
+afterAll(async () => {
+  await Promise.all(fixtures.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("_loadParseSync", () => {
+  it("should use `oxc-parser` when it is installed", async () => {
+    const require = await createRequireFor({ "oxc-parser": reexportRealParser });
+    expect(parse(_loadParseSync(require))).toBe("VariableDeclaration");
+  });
+
+  it("should fall back to `rolldown/utils` when `oxc-parser` is not installed", async () => {
+    const require = await createRequireFor({ "rolldown/utils": reexportRealParser });
+    expect(parse(_loadParseSync(require))).toBe("VariableDeclaration");
+  });
+
+  it("should fall back when a candidate resolves without a `parseSync` export", async () => {
+    const require = await createRequireFor({
+      "oxc-parser": "module.exports = {};",
+      "rolldown/utils": reexportRealParser,
+    });
+    expect(parse(_loadParseSync(require))).toBe("VariableDeclaration");
+  });
+
+  it("should surface the original error when an installed candidate fails to load", async () => {
+    const require = await createRequireFor({
+      "oxc-parser": "throw new Error('missing native binding');",
+    });
+    expect(() => _loadParseSync(require)).toThrow(/found `oxc-parser` but failed to load it/);
+    expect(() => _loadParseSync(require)).toThrow(
+      expect.objectContaining({
+        cause: expect.objectContaining({ message: "missing native binding" }),
+      }),
+    );
+  });
+
+  it("should surface a non-error thrown while loading a candidate", async () => {
+    const require = await createRequireFor({ "oxc-parser": "throw 'boom';" });
+    expect(() => _loadParseSync(require)).toThrow(/found `oxc-parser` but failed to load it/);
+  });
+
+  it("should surface a nested missing module rather than treating it as uninstalled", async () => {
+    const require = await createRequireFor({
+      "oxc-parser": "require('some-missing-transitive-dependency');",
+    });
+    expect(() => _loadParseSync(require)).toThrow(/found `oxc-parser` but failed to load it/);
+  });
+
+  it("should throw when no candidate is installed", async () => {
+    const require = await createRequireFor({});
+    expect(() => _loadParseSync(require)).toThrow(/could not resolve a `parseSync` implementation/);
+  });
+});


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/36163

this provides greater clarity when throwing an error importing rolldown/utils or oxc-parser (typically what's hidden is an error relating to native bindings)